### PR TITLE
deal with system-dependent limit on the lengths of containers

### DIFF
--- a/prettyip.py
+++ b/prettyip.py
@@ -37,10 +37,10 @@ def dashed_range(ipset):
     for pfx in ipset.prefixes:
         pfx_int = pfx.int()
         if range is None or pfx_int != range[1] + 1:
-            range = [pfx_int, pfx_int + len(pfx) - 1]
+            range = [pfx_int, pfx_int + pfx.len() - 1]
             ranges.append(range)
         else:
-            range[1] += len(pfx)
+            range[1] += pfx.len()
 
     def fmtrange(start_int, end_int):
         # bail out early for singletons..


### PR DESCRIPTION
Use the len method on the IP object, rather than calling the builtin len:

> > > from IPy import IP
> > > prefix = IP('0.0.0.0/1')
> > > len(prefix)
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > > OverflowError: long int too large to convert to int
> > > prefix.len()
> > > 2147483648L
